### PR TITLE
patch for pyg dataloader pynb; remove 404 link

### DIFF
--- a/source/pytorch_dataset/link_dataset.py
+++ b/source/pytorch_dataset/link_dataset.py
@@ -54,9 +54,6 @@ class LinkVesselGraph(InMemoryDataset):
 
     available_datasets = {
 
-        'synthetic': {'folder':'synthetic.zip',
-                      'url':'https://syncandshare.lrz.de/dl/fiYbEo8Vv1mpHWtT2ShRqB3i/synthetic.zip',
-                      'AlanBrainAtlas':False, 'extraction_method':'voreen'},
         'synthetic_graph_1': {'folder':'synthetic.zip',
                       'url':'https://syncandshare.lrz.de/dl/fiXfSD14pKGM54L5BqZxF8vF/synthetic_graph_1.zip',
                       'AlanBrainAtlas':False,'extraction_method':'voreen'},

--- a/source/pytorch_dataset/node_dataset.py
+++ b/source/pytorch_dataset/node_dataset.py
@@ -50,10 +50,6 @@ class NodeVesselGraph(InMemoryDataset):
 
     available_datasets = {
 
-        'synthetic': {'folder':'synthetic.zip',
-                      'url':'https://syncandshare.lrz.de/dl/fiYbEo8Vv1mpHWtT2ShRqB3i/synthetic.zip',
-                      'AlanBrainAtlas':False},
-
         'synthetic_graph_1': {'folder':'synthetic.zip',
                       'url':'https://syncandshare.lrz.de/dl/fiXfSD14pKGM54L5BqZxF8vF/synthetic_graph_1.zip',
                       'AlanBrainAtlas':False},

--- a/vesselgraph.ipynb
+++ b/vesselgraph.ipynb
@@ -2,26 +2,28 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# DataLoader Example"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 1. Pytorch-geometric dataloader"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
-    "import os.path as osp\n",
-    "import sys\n",
-    "sys.path.insert(0, 'source')\n",
+    "# import os.path as osp\n",
+    "# import sys\n",
+    "# sys.path.insert(0, 'source')\n",
     "import torch\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -29,40 +31,63 @@
     "import argparse\n",
     "import networkx as nx\n",
     "import torch_geometric.transforms as T\n",
-    "from pytorch_dataset.link_dataset import LinkVesselGraph\n",
-    "from ogb.io import DatasetSaver\n",
-    "from ogb.linkproppred import LinkPropPredDataset\n",
-    "from pytorch_dataset.node_dataset import NodeVesselGraph\n",
-    "from pytorch_dataset.vessap_utils import *\n",
+    "from source.pytorch_dataset.link_dataset import LinkVesselGraph\n",
+    "from source.pytorch_dataset.node_dataset import NodeVesselGraph\n",
+    "from source.pytorch_dataset.vessap_utils import *\n",
     "\n",
     "# for multi-class labeling\n",
     "from sklearn.preprocessing import KBinsDiscretizer"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### 1.1 Link Dataloader"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available Datasets are: dict_keys(['synthetic_graph_1', 'synthetic_graph_2', 'synthetic_graph_3', 'synthetic_graph_4', 'synthetic_graph_5', 'BALBc_no1', 'BALBc_no2', 'BALBc_no3', 'C57BL_6_no1', 'C57BL_6_no2', 'C57BL_6_no3', 'CD1-E_no1', 'CD1-E_no2', 'CD1-E_no3', 'C57BL_6-K18', 'C57BL_6-K19', 'C57BL_6-K20', 'link_vessap_roi1', 'link_vessap_roi3'])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading https://syncandshare.lrz.de/dl/fiPvTKvqhqNtQ8B6UyGfbvGi/synthetic_graph_3.zip\n",
+      "Extracting data/synthetic_graph_3/raw/synthetic_graph_3.zip\n",
+      "Processing...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "data/synthetic_graph_3/raw/synthetic_graph_3/3_b_3_0/3_b_3_0_nodes_processed.csv\n",
+      "data/synthetic_graph_3/raw/synthetic_graph_3/3_b_3_0/3_b_3_0_edges_processed.csv\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Done!\n"
+     ]
+    }
+   ],
    "source": [
-    "dataset = 'BALBc_no1'\n",
+    "dataset = 'synthetic_graph_3'\n",
     "splitting_strategy = 'random'\n",
     "\n",
-    "dataset_name = 'ogbl-' + dataset + '_' + splitting_strategy # e.g. ogbl-BALBc_no1_spatial\n",
-    "dataset_name +=  '_no_edge_attr' \n",
-    "\n",
-    "saver = DatasetSaver(dataset_name = dataset_name,\n",
-    "                    is_hetero = False,\n",
-    "                    version = 1)\n",
-    "\n",
-    "link_dataset = LinkVesselGraph(root='/home/supro/projects/VesselGraph/source/ogb_dataset/link_prediction/data/random/', \n",
+    "link_dataset = LinkVesselGraph(root='data', \n",
     "                          name=dataset,\n",
     "                          splitting_strategy=splitting_strategy,\n",
     "                          number_of_workers = 2,\n",
@@ -70,22 +95,30 @@
     "                          test_ratio = 0.1,\n",
     "                          seed=123,\n",
     "                          )"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Removed existing submission directory\n",
-      "Available Datasets are: dict_keys(['synthetic', 'BALBc_no1', 'BALBc_no2', 'BALBc_no3', 'C57BL_6_no1', 'C57BL_6_no2', 'C57BL_6_no3', 'CD1-E_no1', 'CD1-E_no2', 'CD1-E_no3', 'link_vessap_roi1', 'link_vessap_roi3'])\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset: LinkVesselGraph():\n",
+      "======================\n",
+      "Number of graphs: 1\n",
+      "Number of features: 5\n",
+      "Number of nodes: 3128\n",
+      "Number of edges: 6388\n",
+      "Average node degree: 2.04\n",
+      "Contains isolated nodes: True\n",
+      "Contains self-loops: False\n",
+      "Is directed: False\n"
+     ]
+    }
+   ],
    "source": [
     "data = link_dataset[0]\n",
     "print(f'Dataset: {link_dataset}:')\n",
@@ -98,92 +131,114 @@
     "print(f'Contains isolated nodes: {data.contains_isolated_nodes()}')\n",
     "print(f'Contains self-loops: {data.contains_self_loops()}')\n",
     "print(f'Is directed: {data.is_directed()}')"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Node Dataloader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Dataset: LinkVesselGraph():\n",
+      "Dataset: NodeVesselGraph():\n",
       "======================\n",
       "Number of graphs: 1\n",
       "Number of features: 5\n",
-      "Number of nodes: 3538495\n",
-      "Number of edges: 8553438\n",
-      "Average node degree: 2.42\n",
+      "Number of nodes: 3128\n",
+      "Number of edges: 6388\n",
+      "Average node degree: 2.04\n",
       "Contains isolated nodes: True\n",
       "Contains self-loops: False\n",
       "Is directed: False\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "node_dataset = NodeVesselGraph(root='data', name=dataset, pre_transform=T.LineGraph(force_directed=False))\n",
+    "\n",
+    "data = node_dataset[0]\n",
+    "print(f'Dataset: {node_dataset}:')\n",
+    "print('======================')\n",
+    "print(f'Number of graphs: {len(node_dataset)}')\n",
+    "print(f'Number of features: {node_dataset.num_features}')\n",
+    "print(f'Number of nodes: {data.num_nodes}')\n",
+    "print(f'Number of edges: {data.num_edges}')\n",
+    "print(f'Average node degree: {data.num_edges / data.num_nodes:.2f}')\n",
+    "print(f'Contains isolated nodes: {data.contains_isolated_nodes()}')\n",
+    "print(f'Contains self-loops: {data.contains_self_loops()}')\n",
+    "print(f'Is directed: {data.is_directed()}')"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "### 1.2 Node Dataloader"
-   ],
-   "metadata": {}
+    "## 2. OGB dataloader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "dataset_name = 'ogbn-' + dataset # e.g. ogbl-italo\n",
+    "from source.ogb.io import DatasetSaver\n",
+    "from source.ogb.linkproppred import LinkPropPredDataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = 'ogbl-' + dataset + '_' + splitting_strategy # e.g. ogbl-BALBc_no1_spatial\n",
+    "dataset_name +=  '_no_edge_attr' \n",
     "\n",
-    "dataset = NodeVesselGraph(root='data', name=dataset, pre_transform=T.LineGraph(force_directed=False))"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Downloading https://syncandshare.lrz.de/dl/fiG21AiiCJE6mVRo6tUsNp4N/BALBc_no1.zip\n",
-      "Extracting data/BALBc_no1/raw/BALBc_no1.zip\n",
-      "Processing...\n",
-      "data/BALBc_no1/raw/BALBc_no1/BALBc-no1_iso3um_stitched_segmentation_bulge_size_3.0/BALBc-no1_iso3um_stitched_segmentation_bulge_size_3.0_nodes_processed.csv\n",
-      "data/BALBc_no1/raw/BALBc_no1/BALBc-no1_iso3um_stitched_segmentation_bulge_size_3.0/BALBc-no1_iso3um_stitched_segmentation_bulge_size_3.0_edges_processed.csv\n",
-      "Done!\n"
-     ]
-    }
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "## 2. OGB dataloader"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [],
-   "metadata": {}
+    "saver = DatasetSaver(dataset_name = dataset_name,\n",
+    "                    is_hetero = False,\n",
+    "                    version = 1)\n",
+    "\n",
+    "# another example:\n",
+    "dataset_name = 'ogbn-' + dataset # e.g. ogbl-italo"
+   ]
   }
  ],
  "metadata": {
-  "orig_nbformat": 4,
+  "interpreter": {
+   "hash": "7195a11fd9c3c4c2fabc5aa224f6df5875deefb59ca20d85ed3eb108a9856952"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.6.9 64-bit ('deepro': venv)",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python",
-   "version": "3.6.9",
-   "mimetype": "text/x-python",
    "codemirror_mode": {
     "name": "ipython",
     "version": 3
    },
-   "pygments_lexer": "ipython3",
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
    "nbconvert_exporter": "python",
-   "file_extension": ".py"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
   },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.6.9 64-bit ('deepro': venv)"
-  },
-  "interpreter": {
-   "hash": "7195a11fd9c3c4c2fabc5aa224f6df5875deefb59ca20d85ed3eb108a9856952"
-  }
+  "orig_nbformat": 4
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
removed the 404 links for synthetic dataset: https://syncandshare.lrz.de/dl/fiYbEo8Vv1mpHWtT2ShRqB3i/synthetic.zip in `pytorch_dataset` folder code

patched the toy example notebook which is actually mentioned in README (see screenshot): 
![image](https://user-images.githubusercontent.com/26617036/168476014-c7f61233-6bb0-4138-a7dc-4a494be02966.png)
- separate the ogb dataloader code from the pyg dataloader code
- add `source.` prefix to the custom code dirs in source